### PR TITLE
Checking for `null` before calling moment and replacing with undefined

### DIFF
--- a/anytime.js
+++ b/anytime.js
@@ -18,6 +18,7 @@ var moment = require('moment-timezone')
       }
 
 function createMoment(value) {
+  value = value !== null ? value : undefined
   if (this.options.timezone) return moment.tz(value, this.options.timezone)
 
   return moment(value)

--- a/test/anytime.test.js
+++ b/test/anytime.test.js
@@ -201,4 +201,14 @@ describe('anytime', function () {
 
   })
 
+  it('should not throw when rendered with a null initialValue', function () {
+    var Picker = require('../')
+      , parent = document.createElement('input')
+      , p = new Picker({ input: parent, initialValue: null })
+
+    assert.doesNotThrow(function () {
+      p.render()
+    }, /setAttribute/)
+  })
+
 })


### PR DESCRIPTION
- calling `model.get('startDate')` returns null
- passing this straight into a date picker causes `moment(null)` to be called
- `moment(null)` produces an invalid date object
- `this.currentView.month` becomes equal to NaN
- on `.updateDisplay()` this attempts to set the selected attribute to
`this.monthSelect.children[NaN].setAttribute` which throws due to being non existent