### PR TITLE
Allow customisation of button text

### DIFF
--- a/anytime.js
+++ b/anytime.js
@@ -19,6 +19,8 @@ var Emitter = require('events').EventEmitter
       , format: 'h:mma on dddd D MMMM YYYY'
       , moment: moment
       , minuteIncrement: 1
+      , doneText: 'Done'
+      , clearText: 'Clear'
       }
 
 function AnytimePicker(options) {
@@ -185,14 +187,14 @@ AnytimePicker.prototype.renderFooter = function (footerEl) {
   // 'Done' button
   var doneBtn = document.createElement('button')
   classList(doneBtn).add('anytime-picker__button', 'anytime-picker__button--done')
-  doneBtn.textContent = 'Done'
+  doneBtn.textContent = this.options.doneText
   footerEl.appendChild(doneBtn)
   doneBtn.addEventListener('click', this.hide.bind(this))
 
   // 'Clear' button
   var clearBtn = document.createElement('button')
-  classList(clearBtn).add('anytime-picker__button', 'anytime-picker__button--next')
-  clearBtn.textContent = 'Clear'
+  classList(clearBtn).add('anytime-picker__button', 'anytime-picker__button--clear')
+  clearBtn.textContent = this.options.clearText
   footerEl.appendChild(clearBtn)
   clearBtn.addEventListener('click', function () {
     this.update(null)

--- a/test/anytime.test.js
+++ b/test/anytime.test.js
@@ -250,6 +250,24 @@ describe('anytime', function () {
 
     })
 
+    it('should set "done" and "clear" button text to provided option', function () {
+      var Picker = require('../')
+        , parent = document.createElement('input')
+        , p = new Picker({
+          input: parent,
+          initialValue: null ,
+          doneText: 'Set Time',
+          clearText: 'Goodbye'
+        })
+
+      p.render()
+
+      var doneButton = p.el.querySelector('.anytime-picker__button--done')
+      assert.equal(doneButton.textContent, 'Set Time', 'should set done button text')
+      var clearButton = p.el.querySelector('.anytime-picker__button--clear')
+      assert.equal(clearButton.textContent, 'Goodbye', 'should set clear button text')
+    })
+
   })
 
 })


### PR DESCRIPTION
As discussed in #26 
- added 'doneText' and 'clearText' option
- changed clear-btn class

I changed the class of the clear button to 'anytime-picker__button--clear'. Previously it was
'anytime-picker__button--next', which might have been by mistake?
I can easily reverse this change if wanted.

Also, I don't know where to update the documentation.