### PR TITLE
Prevent picker from being cut off on screen left

### DIFF
--- a/anytime.js
+++ b/anytime.js
@@ -373,7 +373,7 @@ AnytimePicker.prototype.updatePosition = function () {
   this.el.style.top = (position.top + this.root.offsetHeight + this.options.offset) + 'px'
 
   var leftOffset = (position.left + this.root.offsetWidth - this.el.offsetWidth)
-  this.el.style.left = (leftOffset <= 0 ? 0 : leftOffset) + 'px'
+  this.el.style.left = (leftOffset < 0 ? 0 : leftOffset) + 'px'
 }
 
 AnytimePicker.prototype.toggle = function () {

--- a/anytime.js
+++ b/anytime.js
@@ -371,7 +371,9 @@ AnytimePicker.prototype.hide = function () {
 AnytimePicker.prototype.updatePosition = function () {
   var position = { top: this.root.offsetTop, left: this.root.offsetLeft }
   this.el.style.top = (position.top + this.root.offsetHeight + this.options.offset) + 'px'
-  this.el.style.left = (position.left + this.root.offsetWidth - this.el.offsetWidth) + 'px'
+
+  var leftOffset = (position.left + this.root.offsetWidth - this.el.offsetWidth)
+  this.el.style.left = (leftOffset <= 0 ? 0 : leftOffset) + 'px'
 }
 
 AnytimePicker.prototype.toggle = function () {


### PR DESCRIPTION
Tiny part of #23: prevents picker from being positioned too far left and being cut off.

Still need to address if it's too far right, or the screen's too short, etc.